### PR TITLE
Run all flatpak commands so it installs in one layer.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,7 @@ RUN dnf -y update
 RUN dnf -y install flatpak flatpak-builder git
 
 # Install gnome runtimes
-RUN flatpak remote-add --from gnome-nightly https://sdk.gnome.org/gnome-nightly.flatpakrepo
-RUN flatpak install gnome-nightly org.gnome.Sdk
-RUN flatpak install gnome-nightly org.gnome.Platform
+ENV FLATPAK_OSTREE_REPO_MODE=user-only
+RUN flatpak remote-add --from gnome-nightly https://sdk.gnome.org/gnome-nightly.flatpakrepo && flatpak install gnome-nightly org.gnome.Sdk && flatpak install gnome-nightly org.gnome.Platform
 
 CMD ["bash"]


### PR DESCRIPTION
This fix will install all flatpak dependency in one layer.  Otherwise, the installation will fail on the last command.